### PR TITLE
Fix: block unauthenticated GET /users PII disclosure

### DIFF
--- a/src/main/java/kr/pe/jonghak/demo/user/api/UserController.java
+++ b/src/main/java/kr/pe/jonghak/demo/user/api/UserController.java
@@ -1,20 +1,19 @@
 package kr.pe.jonghak.demo.user.api;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController
 @Slf4j
 public class UserController {
     private final UserRepository userRepository;
-    private final List<User> users = new ArrayList<>();
 
     public UserController(UserRepository userRepository) {
         this.userRepository = userRepository;
@@ -29,8 +28,7 @@ public class UserController {
 
     @GetMapping("/users")
     public ResponseEntity<List<User>> getUsers() {
-        List<User> users = userRepository.findAll();
-        log.info("response user list: {}", users);
-        return ResponseEntity.ok(users);
+        log.warn("blocked unauthenticated request to list all users");
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 }


### PR DESCRIPTION
### Motivation
- The `GET /users` endpoint returned the full collection of `User` objects (including `id`, `name`, and `email`) to any caller, causing unauthenticated bulk PII disclosure. 
- The goal is to close the unauthenticated enumeration path with a minimal change that preserves existing user registration behavior.

### Description
- Replace the previous logic in `getUsers()` so it no longer returns the user list and instead returns HTTP `403 Forbidden` with a warning log. 
- Remove the now-unused in-controller in-memory `List<User>` state and add an import for `HttpStatus`. 
- Preserve the existing `POST /users` handler and repository save behavior so user registration remains unchanged.

### Testing
- Ran `./gradlew test` in the environment and the run failed due to a local Java/Gradle compatibility error (`Unsupported class file major version 69`), so automated tests could not be validated here. 
- No unit tests were added or modified as part of this minimal security fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1656eee8748328b5c4dea909814171)