### PR TITLE
Prevent client-controlled Mongo user ID overwrite

### DIFF
--- a/src/main/java/kr/pe/jonghak/demo/user/api/UserController.java
+++ b/src/main/java/kr/pe/jonghak/demo/user/api/UserController.java
@@ -7,22 +7,21 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @Slf4j
 public class UserController {
     private final UserRepository userRepository;
-    private final List<User> users = new ArrayList<>();
-
     public UserController(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 
     @PostMapping("/users")
     public ResponseEntity<User> registerUser(@RequestBody User user) {
-        User registeredUser = userRepository.save(user);
+        User userToRegister = new User(UUID.randomUUID().toString(), user.getName(), user.getEmail());
+        User registeredUser = userRepository.save(userToRegister);
         log.info("registered user: {}", registeredUser.getName());
         return ResponseEntity.ok(registeredUser);
     }


### PR DESCRIPTION
### Motivation
- Fix a high-severity integrity vulnerability where a client-controlled `User.id` (annotated `@Id`) was saved directly with `MongoRepository.save()`, allowing unauthenticated callers to overwrite existing documents by POSTing a known id. 
- Preserve the existing create user API while preventing create-or-update semantics caused by accepting attacker-controlled ids.

### Description
- Change `UserController.registerUser` to build a new `User` with a server-generated id using `UUID.randomUUID().toString()` and save that instance instead of persisting the request-supplied object; the change is in `src/main/java/kr/pe/jonghak/demo/user/api/UserController.java`.
- Remove an unused in-memory `users` field and its import that were vestigial after switching to Mongo persistence.
- Maintain the existing name/email fields from the request so normal user creation behavior is preserved while blocking id-based overwrites.

### Testing
- Ran the project's tests with `./gradlew test --no-daemon` and the build failed in this environment with `Unsupported class file major version 69`, which appears to be a local Java/Gradle compatibility issue rather than a functional regression.  No automated tests were reported failing due to the code change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1657129bb08328b35fb8d7c027fb5b)