### PR TITLE
Add Spring Security, validation, API error handling, and tests for User API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'
     runtimeOnly 'io.grpc:grpc-netty-shaded:1.63.0'

--- a/src/main/java/kr/pe/jonghak/demo/user/api/ApiExceptionHandler.java
+++ b/src/main/java/kr/pe/jonghak/demo/user/api/ApiExceptionHandler.java
@@ -1,0 +1,45 @@
+package kr.pe.jonghak.demo.user.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, String> fieldErrors = new HashMap<>();
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        return ResponseEntity.badRequest().body(errorBody(HttpStatus.BAD_REQUEST, "Validation failed", fieldErrors));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, Object>> handleAccessDenied(AccessDeniedException ignored) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(errorBody(HttpStatus.FORBIDDEN, "Access denied", null));
+    }
+
+    private Map<String, Object> errorBody(HttpStatus status, String message, Map<String, String> details) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", message);
+        if (details != null && !details.isEmpty()) {
+            body.put("details", details);
+        }
+        return body;
+    }
+}

--- a/src/main/java/kr/pe/jonghak/demo/user/api/SecurityConfig.java
+++ b/src/main/java/kr/pe/jonghak/demo/user/api/SecurityConfig.java
@@ -1,8 +1,12 @@
 package kr.pe.jonghak.demo.user.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.User;
@@ -12,11 +16,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, ObjectMapper objectMapper) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
@@ -24,22 +32,43 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/users").authenticated()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex.accessDeniedHandler((request, response, accessDeniedException) -> {
+                    response.setStatus(HttpStatus.FORBIDDEN.value());
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    response.getWriter().write(objectMapper.writeValueAsString(errorBody(HttpStatus.FORBIDDEN, "Access denied", null)));
+                }))
                 .httpBasic(Customizer.withDefaults());
 
         return http.build();
     }
 
     @Bean
-    public UserDetailsService userDetailsService() {
+    public UserDetailsService userDetailsService(
+            @Value("${app.security.admin.username}") String adminUsername,
+            @Value("${app.security.admin.password}") String adminPassword,
+            @Value("${app.security.user.username}") String userUsername,
+            @Value("${app.security.user.password}") String userPassword) {
         PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
-        var admin = User.withUsername("admin")
-                .password(encoder.encode("admin-password"))
+        var admin = User.withUsername(adminUsername)
+                .password(encoder.encode(adminPassword))
                 .roles("ADMIN")
                 .build();
-        var user = User.withUsername("user")
-                .password(encoder.encode("user-password"))
+        var user = User.withUsername(userUsername)
+                .password(encoder.encode(userPassword))
                 .roles("USER")
                 .build();
         return new InMemoryUserDetailsManager(admin, user);
+    }
+
+    private Map<String, Object> errorBody(HttpStatus status, String message, Map<String, String> details) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", message);
+        if (details != null && !details.isEmpty()) {
+            body.put("details", details);
+        }
+        return body;
     }
 }

--- a/src/main/java/kr/pe/jonghak/demo/user/api/SecurityConfig.java
+++ b/src/main/java/kr/pe/jonghak/demo/user/api/SecurityConfig.java
@@ -1,0 +1,45 @@
+package kr.pe.jonghak.demo.user.api;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/users").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/users").authenticated()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        PasswordEncoder encoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        var admin = User.withUsername("admin")
+                .password(encoder.encode("admin-password"))
+                .roles("ADMIN")
+                .build();
+        var user = User.withUsername("user")
+                .password(encoder.encode("user-password"))
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(admin, user);
+    }
+}

--- a/src/main/java/kr/pe/jonghak/demo/user/api/UserController.java
+++ b/src/main/java/kr/pe/jonghak/demo/user/api/UserController.java
@@ -1,7 +1,7 @@
 package kr.pe.jonghak.demo.user.api;
 
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,27 +9,32 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 @RestController
 @Slf4j
 public class UserController {
     private final UserRepository userRepository;
+
     public UserController(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 
     @PostMapping("/users")
-    public ResponseEntity<User> registerUser(@RequestBody User user) {
-        User userToRegister = new User(UUID.randomUUID().toString(), user.getName(), user.getEmail());
+    public ResponseEntity<User> registerUser(@Valid @RequestBody UserCreateRequest userRequest) {
+        User userToRegister = new User(
+                UUID.randomUUID().toString(),
+                userRequest.name().trim(),
+                userRequest.email().trim().toLowerCase(Locale.ROOT)
+        );
         User registeredUser = userRepository.save(userToRegister);
-        log.info("registered user: {}", registeredUser.getName());
+        log.info("registered userId={}", registeredUser.getId());
         return ResponseEntity.ok(registeredUser);
     }
 
     @GetMapping("/users")
     public ResponseEntity<List<User>> getUsers() {
-        log.warn("blocked unauthenticated request to list all users");
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        return ResponseEntity.ok(userRepository.findAll());
     }
 }

--- a/src/main/java/kr/pe/jonghak/demo/user/api/UserCreateRequest.java
+++ b/src/main/java/kr/pe/jonghak/demo/user/api/UserCreateRequest.java
@@ -1,0 +1,17 @@
+package kr.pe.jonghak.demo.user.api;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserCreateRequest(
+        @NotBlank(message = "name is required")
+        @Size(max = 100, message = "name must be at most 100 characters")
+        String name,
+
+        @NotBlank(message = "email is required")
+        @Email(message = "email must be valid")
+        @Size(max = 254, message = "email must be at most 254 characters")
+        String email
+) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,8 @@ grpc.server.port=9090
 
 spring.data.mongodb.uri=${MONGODB_URI}
 spring.data.mongodb.database=${MONGODB_DATABASE}
+
+app.security.admin.username=${APP_SECURITY_ADMIN_USERNAME}
+app.security.admin.password=${APP_SECURITY_ADMIN_PASSWORD}
+app.security.user.username=${APP_SECURITY_USER_USERNAME}
+app.security.user.password=${APP_SECURITY_USER_PASSWORD}

--- a/src/test/java/kr/pe/jonghak/demo/user/api/UserControllerSecurityTests.java
+++ b/src/test/java/kr/pe/jonghak/demo/user/api/UserControllerSecurityTests.java
@@ -42,7 +42,8 @@ class UserControllerSecurityTests {
     @WithMockUser(roles = "USER")
     void getUsersWithUserRoleReturnsForbidden() throws Exception {
         mockMvc.perform(get("/users"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("Access denied"));
     }
 
     @Test

--- a/src/test/java/kr/pe/jonghak/demo/user/api/UserControllerSecurityTests.java
+++ b/src/test/java/kr/pe/jonghak/demo/user/api/UserControllerSecurityTests.java
@@ -1,0 +1,84 @@
+package kr.pe.jonghak.demo.user.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerSecurityTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void getUsersWithoutAuthReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void getUsersWithUserRoleReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getUsersWithAdminRoleReturnsOk() throws Exception {
+        when(userRepository.findAll()).thenReturn(List.of(new User("1", "alice", "a@example.com")));
+
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("1"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void postUsersWithInvalidPayloadReturnsBadRequest() throws Exception {
+        String body = objectMapper.writeValueAsString(new UserCreateRequest("", "not-an-email"));
+
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Validation failed"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void postUsersWithValidPayloadReturnsOk() throws Exception {
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        String body = objectMapper.writeValueAsString(new UserCreateRequest(" Alice ", "Alice@Example.com"));
+
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Alice"))
+                .andExpect(jsonPath("$.email").value("alice@example.com"));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=demo-user-api
+
+app.security.admin.username=admin
+app.security.admin.password=admin-password
+app.security.user.username=user
+app.security.user.password=user-password


### PR DESCRIPTION
### Motivation
- Secure the user endpoints with role-based access controls and add input validation to ensure correct payloads.
- Provide consistent JSON error responses for validation and access-denied errors.
- Enable basic authentication for local testing and add automated tests to verify security and validation behavior.

### Description
- Added security and validation dependencies in `build.gradle` including `spring-boot-starter-security`, `spring-boot-starter-validation`, and `spring-security-test` for tests.
- Introduced `SecurityConfig` which configures HTTP Basic auth, disables CSRF, enforces `GET /users` for `ADMIN` and `POST /users` for authenticated users, and registers in-memory `admin` and `user` accounts.
- Added `UserCreateRequest` record with `@NotBlank`, `@Size`, and `@Email` constraints and updated `UserController` to accept `@Valid UserCreateRequest`, trim the name, and normalize the email to lowercase while logging the created user id.
- Implemented `ApiExceptionHandler` to return structured JSON error bodies for `MethodArgumentNotValidException` and `AccessDeniedException`.
- Added `UserControllerSecurityTests` integration tests using `@SpringBootTest` and `MockMvc` to validate unauthenticated/role access rules and request validation/normalization behaviors.

### Testing
- Ran the test suite with `./gradlew test` which executed the added `UserControllerSecurityTests` and existing tests successfully.
- Security and validation tests for unauthenticated access, role-based access, validation errors, and successful user creation all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16737ef4d483289352cfd1c417aea0)