### PR TITLE
Upgrade Gradle wrapper to 9.1.0 and set Java toolchain to Java 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Motivation
- Move the project to a newer Gradle runtime and JDK toolchain to stay current with build tooling and language features.
- Ensure the build uses a Java version aligned with target platform expectations and newer Gradle requirements.

### Description
- Update `java.toolchain.languageVersion` from `JavaLanguageVersion.of(21)` to `JavaLanguageVersion.of(25)` in `build.gradle`.
- Bump the Gradle wrapper distribution URL from `gradle-8.10.2-bin.zip` to `gradle-9.1.0-bin.zip` in `gradle/wrapper/gradle-wrapper.properties`.
- No other dependency or plugin versions were changed in this patch.

### Testing
- Ran `./gradlew --version` with the updated wrapper to verify the Gradle runtime upgraded to `9.1.0`, which succeeded.
- Executed `./gradlew test` and the automated test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a167c66590883288136212f143bd896)