### PR TITLE
Add PR template to require explicit test execution details and evidence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+- 
+
+## Testing
+- 실행 명령: `./gradlew test --tests '*UserControllerSecurityTests' -q`
+- 실패 지점: Gradle plugin/dependency resolution 단계
+- 실패 원인: 컨테이너의 외부 저장소 접근 제약 또는 프록시 정책
+- 미실행 범위: 테스트 클래스 로딩/실행 이전 중단
+
+## Evidence Log (3~5 lines)
+```text
+<실행 로그에서 핵심 실패 스택 3~5줄을 여기에 첨부>
+```
+
+> 주의: `all tests passing` 같은 단정 문구는 사용하지 않습니다.


### PR DESCRIPTION
### Motivation
- Prevent assertive test-status statements like `all tests passing` and improve PR auditability by requiring exact execution command, failure point, failure cause, not-executed scope, and a short failure log excerpt when dependency resolution or network policies block test execution.

### Description
- Add `.github/PULL_REQUEST_TEMPLATE.md` with a `Testing` section that requires the executed command (`./gradlew test --tests '*UserControllerSecurityTests' -q`), the failure point (Gradle plugin/dependency resolution), the failure cause (container external repository access restriction or proxy/proxy policy), the not-executed scope (test class loading/execution did not start), an `Evidence Log` placeholder for 3–5 lines of the failure stack, and a note prohibiting assertive phrases like `all tests passing`.

### Testing
- Verified the template file and its contents using `nl -ba .github/PULL_REQUEST_TEMPLATE.md`, which displayed the expected sections and lines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a167efda7648328a8b25cb99c76cd4c)