### PR TITLE
Follow-up: align Docker runtime with Java 25 for PR #19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21-alpine
+FROM amazoncorretto:25-alpine
 LABEL authors="jonghak"
 
 COPY build/libs/*.jar app.jar


### PR DESCRIPTION
### Motivation
- The project build was updated to use a Java 25 toolchain which can emit Java 25 bytecode, and the runtime image must be updated to avoid `UnsupportedClassVersionError` when the app runs in its container. 

### Description
- Updated the Docker runtime base image in `Dockerfile` from `amazoncorretto:21-alpine` to `amazoncorretto:25-alpine` to align the container JVM with the build toolchain. 

### Testing
- Attempted to run `./gradlew test` in this environment, but the Gradle wrapper download failed due to an outbound proxy error (`HTTP/1.1 403 Forbidden`), so the test run could not complete. 
- Verified the `Dockerfile` change is present (`FROM amazoncorretto:25-alpine`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168e97a6748328bbefa27d677c9ddd)