### PR TITLE
Harden feature branch CI to avoid DockerHub secret exposure

### DIFF
--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set environment variables
         id: set-env-vars
         run: |
@@ -48,5 +42,5 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:${{ steps.set-env-vars.outputs.IMAGE_TAG }}
+          push: false
+          tags: ${{ github.event.repository.name }}:${{ steps.set-env-vars.outputs.IMAGE_TAG }}


### PR DESCRIPTION
### Motivation
- A workflow triggered on non-`main` pushes executed branch-controlled `./gradlew test build` before performing DockerHub login and push, which allowed branch-controlled code to persist and exfiltrate DockerHub credentials or publish images in the official namespace. 
- The change aims to eliminate the CI supply-chain risk by ensuring feature-branch builds do not receive or use repository DockerHub secrets in the same runner.

### Description
- Removed the `docker/login-action` step that consumed `secrets.DOCKER_USERNAME` and `secrets.DOCKERHUB_TOKEN` from `.github/workflows/feature-build.yml` to prevent secret-bearing steps in the same job as untrusted build code. 
- Changed the `docker/build-push-action` invocation to `push: false` so images are built but not pushed to remote registries. 
- Switched image tag construction to a local tag that does not reference the secret-backed DockerHub username, preserving local build artifacts for debugging without publishing. 
- Preserved existing build steps (`./gradlew test build`) and Docker Buildx setup so feature-branch validation remains functional without secret exposure.

### Testing
- Inspected the updated workflow file with `nl -ba .github/workflows/feature-build.yml | sed -n '1,220p'` and confirmed the login step was removed and `push: false` is set, which succeeded. 
- Verified repository status with `git status --short` and committed the change with `git commit -m "Harden feature workflow by removing DockerHub secret usage"`, and the commit succeeded. 
- No repository unit/integration tests were executed as part of this change; the modifications are limited to CI configuration and were validated via file inspection and commit success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16575803d48328a2123aef0199c465)