### PR TITLE
Specify Lombok version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 lombok {
-    version = '1.18.38'
+    version = '1.18.40'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ repositories {
     mavenCentral()
 }
 
+lombok {
+    version = '1.18.38'
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
### Motivation
- Ensure a specific Lombok version is used by the Gradle build to avoid mismatches between the `io.freefair.lombok` plugin and project code generation. 

### Description
- Add a `lombok` configuration block to `build.gradle` with `version = '1.18.38'` to pin the Lombok version. 

### Testing
- Ran `./gradlew test` and `./gradlew build` against the modified project and the automated builds and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c436725883288e91b162f2357231)