### PR TITLE
feat: Java toolchain을 25 기본값 + property 기반 동적 설정으로 전환

### DIFF
--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '21'
+          java-version: '25'
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -27,7 +27,7 @@ jobs:
       - name: Run build with Gradle Wrapper
         id: gradle_build
         shell: bash
-        run: ./gradlew test build --stacktrace --info | tee gradle-build.log
+        run: ./gradlew test build -PjavaVersion=25 --stacktrace --info | tee gradle-build.log
 
       - name: Upload Gradle build artifacts
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# demo-user-api
+
+## Java Toolchain
+
+이 프로젝트는 Gradle toolchain의 Java 버전을 `javaVersion` property로 동적으로 설정합니다.
+기본값은 Java 25입니다.
+
+- 기본 실행(=Java 25):
+
+```bash
+./gradlew test
+```
+
+- 명시적으로 Java 25 검증:
+
+```bash
+./gradlew test -PjavaVersion=25
+```
+
+- 다른 버전으로 검증(예: Java 21):
+
+```bash
+./gradlew test -PjavaVersion=21
+```

--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,14 @@ plugins {
     id 'com.google.protobuf' version '0.9.4'
 }
 
+def targetJava = providers.gradleProperty("javaVersion").orElse("25").get()
+
 group = 'kr.pe.jonghak'
 version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(targetJava as int)
     }
 }
 


### PR DESCRIPTION
### Motivation
- Gradle toolchain의 기본 Java 버전을 상향하여 Java 25를 기본 타겟으로 설정하고, 필요 시 Gradle property로 동적으로 오버라이드 가능하도록 변경하기 위함입니다.
- CI와 개발 문서를 Java 25 기준으로 맞춰 기본 검증 경로를 통일하려는 목적입니다.

### Description
- `build.gradle`에 `def targetJava = providers.gradleProperty("javaVersion").orElse("25").get()`를 추가하고 `languageVersion = JavaLanguageVersion.of(targetJava as int)`로 toolchain을 동적으로 설정하도록 변경했습니다.
- GitHub Actions 워크플로우(`.github/workflows/feature-build.yml`)에서 `setup-java`의 `java-version`을 `25`로 상향하고 빌드 명령에 `-PjavaVersion=25`를 명시했습니다.
- 프로젝트 루트에 `README.md`를 추가해 기본 실행과 Java 버전 오버라이드 방법(`./gradlew test -PjavaVersion=25`)을 문서화했습니다.

### Testing
- 로컬에서 `./gradlew test -PjavaVersion=25`를 실행해 자동화된 테스트를 시도했으나, 현재 환경에서 Gradle/Groovy가 `Unsupported class file major version 69` 오류를 발생시켜 빌드가 실패했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16e04df1388328a2be316166750db5)